### PR TITLE
Extracting more error details for validation

### DIFF
--- a/firehoser.js
+++ b/firehoser.js
@@ -27,7 +27,8 @@ class DeliveryStream{
         }
         let validationErrors = schemaValidator.validate(record, this.schema);
         if(!_.isEmpty(validationErrors)){
-            throw new Error("Invalid Record: " + validationErrors);
+            let unwrapped = _.map(validationErrors,ve=>{return _.fromPairs(_.map(ve,(v,k)=>{return [k,v];}))}));
+            throw new Error("Invalid Record: " + unwrapped);
         }
     }
 


### PR DESCRIPTION
consider unwrapping the validationError array, as it doesn't seem to have a good .toString() behavior for actually debugging the problematic validations.
Example error structure:

```
{ 
    instanceContext: '#/timestamp',
    resolutionScope: 'anon-schema://f92b3c233315ac8c9f203d009e3098ad5322732f/#/properties/timestamp',
    constraintName: 'format',
    constraintValue: 'date-time',
    testedValue: '2016-05-18 21:24:39',
    desc: 'not a valid date-time per RFC 3339 section 5.6 (use "date" for date-only or "time" for time-only)',
    kind: 'FormatValidationError' 
}
```
