### PR TITLE
add PlainDeliveryStream

### DIFF
--- a/firehoser.js
+++ b/firehoser.js
@@ -189,6 +189,11 @@ class QueuableJSONDeliveryStream extends QueuableDeliveryStream {
     }
 }
 
+class PlainDeliveryStream extends DeliveryStream {
+    formatRecord(record){
+        return { Data: record };
+    }
+}
 
 function buildSchemaErrorDescription(ve){
     if (ve.desc){
@@ -208,5 +213,6 @@ module.exports = {
     JSONDeliveryStream: JSONDeliveryStream,
     QueuableDeliveryStream: QueuableDeliveryStream,
     QueuableJSONDeliveryStream: QueuableJSONDeliveryStream,
+    PlainDeliveryStream: PlainDeliveryStream,
     makeRedshiftTimestamp: makeRedshiftTimestamp
 };


### PR DESCRIPTION
Hey,

I added a PlainDeliveryStream class which does not do any formatting (appending \n).
I needed to write binary messages with my own separation technique.

It will be useful for people wanting Buffer not to convert to string and giving ability to specify different suffix.

Thanks for a great library